### PR TITLE
Changed default mapping of property names to case sensitive. Can conf…

### DIFF
--- a/ElasticsearchCRUD/ContextAddDeleteUpdate/ElasticsearchSerializer.cs
+++ b/ElasticsearchCRUD/ContextAddDeleteUpdate/ElasticsearchSerializer.cs
@@ -72,6 +72,7 @@ namespace ElasticsearchCRUD.ContextAddDeleteUpdate
 			elasticSearchMapping.TraceProvider = _traceProvider;
 			elasticSearchMapping.SaveChildObjectsAsWellAsParent = _elasticsearchSerializerConfiguration.SaveChildObjectsAsWellAsParent;
 			elasticSearchMapping.ProcessChildDocumentsAsSeparateChildIndex = _elasticsearchSerializerConfiguration.ProcessChildDocumentsAsSeparateChildIndex;
+		    elasticSearchMapping.MapToLowerCase = _elasticsearchSerializerConfiguration.MapToLowerCase;
 			_elasticsearchCrudJsonWriter.JsonWriter.WriteStartObject();
 
 			_elasticsearchCrudJsonWriter.JsonWriter.WritePropertyName("delete");
@@ -103,6 +104,7 @@ namespace ElasticsearchCRUD.ContextAddDeleteUpdate
 			elasticSearchMapping.TraceProvider = _traceProvider;
 			elasticSearchMapping.SaveChildObjectsAsWellAsParent = _elasticsearchSerializerConfiguration.SaveChildObjectsAsWellAsParent;
 			elasticSearchMapping.ProcessChildDocumentsAsSeparateChildIndex = _elasticsearchSerializerConfiguration.ProcessChildDocumentsAsSeparateChildIndex;
+		    elasticSearchMapping.MapToLowerCase = _elasticsearchSerializerConfiguration.MapToLowerCase;
 
 			CreateBulkContentForParentDocument(entityInfo, elasticSearchMapping);
 

--- a/ElasticsearchCRUD/ElasticSearchMapping.cs
+++ b/ElasticsearchCRUD/ElasticSearchMapping.cs
@@ -52,7 +52,7 @@ namespace ElasticsearchCRUD
 					{
 						if (Attribute.IsDefined(prop, typeof (ElasticsearchGeoTypeAttribute))) 
 						{
-							var obj = prop.Name.ToLower(MapToLowerCase);
+							var obj = prop.Name().ToLower(MapToLowerCase);
 							// process GeoTypes
 							if (createPropertyMappings)
 							{
@@ -86,11 +86,11 @@ namespace ElasticsearchCRUD
 							{
 								if (!ProcessChildDocumentsAsSeparateChildIndex || ProcessChildDocumentsAsSeparateChildIndex && beginMappingTree)
 								{
-									TraceProvider.Trace(TraceEventType.Verbose, "ElasticsearchMapping: Property is a simple Type: {0}, {1}", prop.Name.ToLower(MapToLowerCase), prop.PropertyType.FullName);
+									TraceProvider.Trace(TraceEventType.Verbose, "ElasticsearchMapping: Property is a simple Type: {0}, {1}", prop.Name().ToLower(MapToLowerCase), prop.PropertyType.FullName);
 
 									if (createPropertyMappings)
 									{
-										var obj = prop.Name.ToLower(MapToLowerCase);
+										var obj = prop.Name().ToLower(MapToLowerCase);
 										if (Attribute.IsDefined(prop, typeof (ElasticsearchCoreTypes)))
 										{									
 											object[] attrs = prop.GetCustomAttributes(typeof (ElasticsearchCoreTypes), true);
@@ -119,7 +119,8 @@ namespace ElasticsearchCRUD
 									}
 									else
 									{
-										MapValue(prop.Name.ToLower(MapToLowerCase), prop.GetValue(entityInfo.Document), elasticsearchCrudJsonWriter.JsonWriter);
+
+									    MapValue(prop.Name().ToLower(MapToLowerCase), prop.GetValue(entityInfo.Document), elasticsearchCrudJsonWriter.JsonWriter);
 									}
 
 								}
@@ -175,7 +176,7 @@ namespace ElasticsearchCRUD
 
 		private void ProcessArrayOrCollection(EntityContextInfo entityInfo, ElasticsearchCrudJsonWriter elasticsearchCrudJsonWriter, PropertyInfo prop, bool createPropertyMappings)
 		{
-			TraceProvider.Trace(TraceEventType.Verbose, "ElasticsearchMapping: IsPropertyACollection: {0}", prop.Name.ToLower(MapToLowerCase));
+			TraceProvider.Trace(TraceEventType.Verbose, "ElasticsearchMapping: IsPropertyACollection: {0}", prop.Name().ToLower(MapToLowerCase));
 
 			if (createPropertyMappings && prop.GetValue(entityInfo.Document) == null)
 			{
@@ -204,7 +205,7 @@ namespace ElasticsearchCRUD
 
 		private void ProcessSingleObjectAsNestedObject(EntityContextInfo entityInfo, ElasticsearchCrudJsonWriter elasticsearchCrudJsonWriter, PropertyInfo prop, bool createPropertyMappings)
 		{
-			elasticsearchCrudJsonWriter.JsonWriter.WritePropertyName(prop.Name.ToLower(MapToLowerCase));
+			elasticsearchCrudJsonWriter.JsonWriter.WritePropertyName(prop.Name().ToLower(MapToLowerCase));
 			elasticsearchCrudJsonWriter.JsonWriter.WriteStartObject();
 
 			if (createPropertyMappings)
@@ -281,8 +282,8 @@ namespace ElasticsearchCRUD
 
 		private void ProcessArrayOrCollectionAsNestedObject(EntityContextInfo entityInfo, ElasticsearchCrudJsonWriter elasticsearchCrudJsonWriter, PropertyInfo prop, bool createPropertyMappings)
 		{
-			elasticsearchCrudJsonWriter.JsonWriter.WritePropertyName(prop.Name.ToLower(MapToLowerCase));
-			TraceProvider.Trace(TraceEventType.Verbose, "ElasticsearchMapping: BEGIN ARRAY or COLLECTION: {0} {1}", prop.Name.ToLower(MapToLowerCase), elasticsearchCrudJsonWriter.JsonWriter.Path);
+			elasticsearchCrudJsonWriter.JsonWriter.WritePropertyName(prop.Name().ToLower(MapToLowerCase));
+			TraceProvider.Trace(TraceEventType.Verbose, "ElasticsearchMapping: BEGIN ARRAY or COLLECTION: {0} {1}", prop.Name().ToLower(MapToLowerCase), elasticsearchCrudJsonWriter.JsonWriter.Path);
 			var typeOfEntity = prop.GetValue(entityInfo.Document).GetType().GetGenericArguments();
 			if (typeOfEntity.Length > 0)
 			{
@@ -306,7 +307,7 @@ namespace ElasticsearchCRUD
 			else
 			{
 				TraceProvider.Trace(TraceEventType.Verbose, "ElasticsearchMapping: BEGIN ARRAY or COLLECTION NOT A GENERIC: {0}",
-					prop.Name.ToLower(MapToLowerCase));
+					prop.Name().ToLower(MapToLowerCase));
 				// Not a generic
 				MapCollectionOrArray(prop, entityInfo, elasticsearchCrudJsonWriter, createPropertyMappings);
 			}
@@ -314,7 +315,7 @@ namespace ElasticsearchCRUD
 
 		private void ProcessArrayOrCollectionAsChildDocument(EntityContextInfo entityInfo, ElasticsearchCrudJsonWriter elasticsearchCrudJsonWriter, PropertyInfo prop, bool createPropertyMappings)
 		{
-			TraceProvider.Trace(TraceEventType.Verbose, "ElasticsearchMapping: BEGIN ARRAY or COLLECTION: {0} {1}", prop.Name.ToLower(MapToLowerCase), elasticsearchCrudJsonWriter.JsonWriter.Path);
+			TraceProvider.Trace(TraceEventType.Verbose, "ElasticsearchMapping: BEGIN ARRAY or COLLECTION: {0} {1}", prop.Name().ToLower(MapToLowerCase), elasticsearchCrudJsonWriter.JsonWriter.Path);
 			var typeOfEntity = prop.GetValue(entityInfo.Document).GetType().GetGenericArguments();
 			if (typeOfEntity.Length > 0)
 			{
@@ -335,7 +336,7 @@ namespace ElasticsearchCRUD
 			else
 			{
 				TraceProvider.Trace(TraceEventType.Verbose, "ElasticsearchMapping: BEGIN ARRAY or COLLECTION NOT A GENERIC: {0}",
-					prop.Name.ToLower(MapToLowerCase));
+					prop.Name().ToLower(MapToLowerCase));
 				// Not a generic
 				MapCollectionOrArray(prop, entityInfo, elasticsearchCrudJsonWriter, createPropertyMappings);
 			}

--- a/ElasticsearchCRUD/ElasticsearchCRUD.csproj
+++ b/ElasticsearchCRUD/ElasticsearchCRUD.csproj
@@ -421,6 +421,7 @@
     <Compile Include="Model\ResultDetails.cs" />
     <Compile Include="Tracing\TraceProvider.cs" />
     <Compile Include="Utils\ParameterCollection.cs" />
+    <Compile Include="Utils\StringExtensions.cs" />
     <Compile Include="Utils\SyncExecute.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ElasticsearchCRUD/ElasticsearchSerializerConfiguration.cs
+++ b/ElasticsearchCRUD/ElasticsearchSerializerConfiguration.cs
@@ -10,12 +10,13 @@
 		private readonly bool _processChildDocumentsAsSeparateChildIndex;
 		private readonly bool _userDefinedRouting;
 
-		public ElasticsearchSerializerConfiguration(IElasticsearchMappingResolver elasticsearchMappingResolver, bool saveChildObjectsAsWellAsParent = true, bool processChildDocumentsAsSeparateChildIndex = false, bool userDefinedRouting=false)
+	    public ElasticsearchSerializerConfiguration(IElasticsearchMappingResolver elasticsearchMappingResolver, bool saveChildObjectsAsWellAsParent = true, bool processChildDocumentsAsSeparateChildIndex = false, bool userDefinedRouting=false, bool mapToLowerCase = false)
 		{
 			_elasticsearchMappingResolver = elasticsearchMappingResolver;
 			_saveChildObjectsAsWellAsParent = saveChildObjectsAsWellAsParent;
 			_processChildDocumentsAsSeparateChildIndex = processChildDocumentsAsSeparateChildIndex;
 			_userDefinedRouting = userDefinedRouting;
+		    MapToLowerCase = mapToLowerCase;
 		}
 
 		/// <summary>
@@ -52,5 +53,7 @@
 		{
 			get { return _userDefinedRouting; }
 		}
+
+        public bool MapToLowerCase { get; }
 	}
 }

--- a/ElasticsearchCRUD/Utils/JsonHelper.cs
+++ b/ElasticsearchCRUD/Utils/JsonHelper.cs
@@ -1,5 +1,8 @@
 ﻿
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
 
 namespace ElasticsearchCRUD.Utils
 {
@@ -61,5 +64,13 @@ namespace ElasticsearchCRUD.Utils
 				elasticsearchCrudJsonWriter.JsonWriter.WriteEndArray();
 			}
 		}
-	}
+
+	    public static string Name(this PropertyInfo prop)
+	    {
+            var jsonProperty = prop.CustomAttributes.FirstOrDefault(x => x.AttributeType.IsAssignableFrom(typeof(JsonPropertyAttribute)));
+            return jsonProperty != null && jsonProperty.ConstructorArguments.Any() 
+                                ? jsonProperty.ConstructorArguments[0].Value as string 
+                                : prop.Name;
+	    }
+    }
 }

--- a/ElasticsearchCRUD/Utils/StringExtensions.cs
+++ b/ElasticsearchCRUD/Utils/StringExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace ElasticsearchCRUD.Utils
+{
+    public static class StringExtensions
+    {
+        public static string ToLower(this string str, bool toLower)
+        {
+            return toLower ? str.ToLower() : str;
+        }
+    }
+}


### PR DESCRIPTION
Changed default mapping of property names to case sensitive. Can be configured in ElasticsearchSerializerConfiguration ctor to enable lower case stategy on all property names. Implementation is as non-invasive as possible with the use of an extension method. 

Example: configure lower case strategy
```
            return new ElasticsearchContext(
								"http://dev-es.hyperv.lc.skejby:9200/",
								new ElasticsearchSerializerConfiguration(
														CreateMappingResolver(date),
														saveChildObjectsAsWellAsParent:true,
														processChildDocumentsAsSeparateChildIndex:false,
														userDefinedRouting:false,
														mapToLowerCase:true)
                );
```

Example: configure case sensitive strategy (default)
```
            return new ElasticsearchContext(
								"http://dev-es.hyperv.lc.skejby:9200/",
								new ElasticsearchSerializerConfiguration(
														CreateMappingResolver(date))
                );
```

