### PR TITLE
Case sensitive property name configuration

### DIFF
--- a/ElasticsearchCRUD/ContextAddDeleteUpdate/ElasticsearchSerializer.cs
+++ b/ElasticsearchCRUD/ContextAddDeleteUpdate/ElasticsearchSerializer.cs
@@ -72,6 +72,7 @@ namespace ElasticsearchCRUD.ContextAddDeleteUpdate
 			elasticSearchMapping.TraceProvider = _traceProvider;
 			elasticSearchMapping.SaveChildObjectsAsWellAsParent = _elasticsearchSerializerConfiguration.SaveChildObjectsAsWellAsParent;
 			elasticSearchMapping.ProcessChildDocumentsAsSeparateChildIndex = _elasticsearchSerializerConfiguration.ProcessChildDocumentsAsSeparateChildIndex;
+		    elasticSearchMapping.MapToLowerCase = _elasticsearchSerializerConfiguration.MapToLowerCase;
 			_elasticsearchCrudJsonWriter.JsonWriter.WriteStartObject();
 
 			_elasticsearchCrudJsonWriter.JsonWriter.WritePropertyName("delete");
@@ -103,6 +104,7 @@ namespace ElasticsearchCRUD.ContextAddDeleteUpdate
 			elasticSearchMapping.TraceProvider = _traceProvider;
 			elasticSearchMapping.SaveChildObjectsAsWellAsParent = _elasticsearchSerializerConfiguration.SaveChildObjectsAsWellAsParent;
 			elasticSearchMapping.ProcessChildDocumentsAsSeparateChildIndex = _elasticsearchSerializerConfiguration.ProcessChildDocumentsAsSeparateChildIndex;
+		    elasticSearchMapping.MapToLowerCase = _elasticsearchSerializerConfiguration.MapToLowerCase;
 
 			CreateBulkContentForParentDocument(entityInfo, elasticSearchMapping);
 

--- a/ElasticsearchCRUD/ElasticsearchCRUD.csproj
+++ b/ElasticsearchCRUD/ElasticsearchCRUD.csproj
@@ -421,6 +421,7 @@
     <Compile Include="Model\ResultDetails.cs" />
     <Compile Include="Tracing\TraceProvider.cs" />
     <Compile Include="Utils\ParameterCollection.cs" />
+    <Compile Include="Utils\StringExtensions.cs" />
     <Compile Include="Utils\SyncExecute.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ElasticsearchCRUD/ElasticsearchSerializerConfiguration.cs
+++ b/ElasticsearchCRUD/ElasticsearchSerializerConfiguration.cs
@@ -10,12 +10,13 @@
 		private readonly bool _processChildDocumentsAsSeparateChildIndex;
 		private readonly bool _userDefinedRouting;
 
-		public ElasticsearchSerializerConfiguration(IElasticsearchMappingResolver elasticsearchMappingResolver, bool saveChildObjectsAsWellAsParent = true, bool processChildDocumentsAsSeparateChildIndex = false, bool userDefinedRouting=false)
+	    public ElasticsearchSerializerConfiguration(IElasticsearchMappingResolver elasticsearchMappingResolver, bool saveChildObjectsAsWellAsParent = true, bool processChildDocumentsAsSeparateChildIndex = false, bool userDefinedRouting=false, bool mapToLowerCase = false)
 		{
 			_elasticsearchMappingResolver = elasticsearchMappingResolver;
 			_saveChildObjectsAsWellAsParent = saveChildObjectsAsWellAsParent;
 			_processChildDocumentsAsSeparateChildIndex = processChildDocumentsAsSeparateChildIndex;
 			_userDefinedRouting = userDefinedRouting;
+		    MapToLowerCase = mapToLowerCase;
 		}
 
 		/// <summary>
@@ -52,5 +53,7 @@
 		{
 			get { return _userDefinedRouting; }
 		}
+
+        public bool MapToLowerCase { get; }
 	}
 }

--- a/ElasticsearchCRUD/Utils/StringExtensions.cs
+++ b/ElasticsearchCRUD/Utils/StringExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace ElasticsearchCRUD.Utils
+{
+    public static class StringExtensions
+    {
+        public static string ToLower(this string str, bool toLower)
+        {
+            return toLower ? str.ToLower() : str;
+        }
+    }
+}


### PR DESCRIPTION
Changed default mapping of property names to case sensitive. Can be configured in ElasticsearchSerializerConfiguration ctor to enable lower case stategy on all property names. Implementation is as non-invasive as possible with the use of an extension method. 

Example: configure lower case strategy

```
            return new ElasticsearchContext(
                                "http://localhost:9200/",
                                new ElasticsearchSerializerConfiguration(
                                                        CreateMappingResolver(date),
                                                        saveChildObjectsAsWellAsParent:true,
                                                        processChildDocumentsAsSeparateChildIndex:false,
                                                        userDefinedRouting:false,
                                                        mapToLowerCase:true)
                );
```

Example: configure case sensitive strategy (default)

```
            return new ElasticsearchContext(
                                "http://localhost:9200/",
                                new ElasticsearchSerializerConfiguration(
                                                        CreateMappingResolver(date))
                );
```
